### PR TITLE
feat: Add systemd service and pkgbuild

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Stephen Smith <stephen304@gmail.com>
+
+pkgname=castblock-crystal-git
+_pkgname=castblock
+_branch=main
+pkgver=8.83237c8
+pkgrel=1
+pkgdesc="CastBlock skips integrated youtube sponsors on all chromecasts on the network, crystal rewrite"
+arch=('any')
+url="https://github.com/erdnaxeli/castblock"
+license=('MIT')
+depends=('go-chromecast-git')
+makedepends=('crystal' 'shards')
+provides=('castblock')
+conflicts=('castblock' 'castblock-git')
+source=("$_pkgname::git+${url}.git#branch=$_branch")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/$_pkgname"
+  echo $(git rev-list --count "$_branch").$(git rev-parse --short "$_branch")
+}
+
+build() {
+  cd "$srcdir/$_pkgname"
+  shards build --release
+}
+
+package() {
+  cd "$srcdir/$_pkgname"
+
+  install -Dm755 ./bin/castblock "${pkgdir}/usr/bin/castblock"
+  install -Dm644 contrib/castblock.service "$pkgdir"/usr/lib/systemd/system/castblock.service
+}

--- a/contrib/castblock.service
+++ b/contrib/castblock.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=CastBlock Service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/castblock
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These are a bit trivial, but it might be nice to have in the repo. I'm thinking about either uploading the PKGBUILD to the AUR under castblock-crystal-git or maybe later switching castblock-git to be packaged from this repo.

I think this version is the easiest upgrade path since you've also made a docker container as well as solving the major limitations of my version. What do you think? I'm currently dogfooding but so far it looks good.