### PR TITLE
Feature: Mute native youtube ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Available options:
   It can be repeated to specify many categories.
   Default to "sponsor".
 * `--mute-ads`: enable auto mute during native YouTube ads. These are different
-  from in-video sponsors, and are typically blocked by browser extension ad blockers
+  from in-video sponsors, and are typically blocked by browser extension ad blockers.
 
 ## Contributing
 
@@ -61,3 +61,4 @@ Available options:
 ## Contributors
 
 - [erdnaxeli](https://github.com/erdnaxeli) - creator and maintainer
+- [stephen304](https://github.com/stephen304) - contributor and ad blocking enthusiast

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Available options:
 * `--category`: specify the category of segment to skip.
   It can be repeated to specify many categories.
   Default to "sponsor".
+* `--mute-ads`: enable auto mute during native YouTube ads. These are different
+  from in-video sponsors, and are typically blocked by browser extension ad blockers
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ All options can also be read from the environment variables:
 * `DEBUG=true`
 * `OFFSET=1`
 * `CATEGORIES=sponsor,interaction`
+* `MUTE_ADS=true`
 
 ## Contributing
 

--- a/src/blocker.cr
+++ b/src/blocker.cr
@@ -59,7 +59,7 @@ class Castblock::Blocker
         end
       end
 
-      if @mute_ads && (payload = message.payload_data)
+      if @mute_ads && (payload = message.payload_data) && payload.status.size > 0
         if payload.status[0].custom_data.player_state == 1081 && payload.status[0].volume.muted == false
           Log.info &.emit("Found ad, muting audio", device: device.name)
           @chromecast.set_mute(device, true)

--- a/src/blocker.cr
+++ b/src/blocker.cr
@@ -110,10 +110,10 @@ class Castblock::Blocker
 
   private def handle_monetization(device : Chromecast::Device, player_state : Int) : Nil
     if player_state == 1081
-      Log.info &.emit("Found ad, muting audio", device: device.device_name)
+      Log.info &.emit("Found ad, muting audio", device: device.name)
       @chromecast.set_mute(device, true)
     else
-      Log.info &.emit("Ad ended, unmuting audio", device: device.device_name)
+      Log.info &.emit("Ad ended, unmuting audio", device: device.name)
       @chromecast.set_mute(device, false)
     end
   end

--- a/src/castblock.cr
+++ b/src/castblock.cr
@@ -38,6 +38,10 @@ module Castblock
       if @categories == ["sponsor"] && (categories = ENV["CATEGORIES"]?)
         @categories = categories.split(',')
       end
+
+      if @mute_ads == false && (mute_ads = ENV["MUTE_ADS"]?)
+        @mute_ads = mute_ads.downcase == "true"
+      end
     end
 
     def run : Nil

--- a/src/castblock.cr
+++ b/src/castblock.cr
@@ -13,6 +13,7 @@ module Castblock
     include Clip::Mapper
 
     @debug : Bool? = nil
+    @mute_ads : Bool = false
 
     def run
       if @debug
@@ -21,7 +22,7 @@ module Castblock
 
       chromecast = Chromecast.new
       sponsorblock = Sponsorblock.new
-      blocker = Blocker.new(chromecast, sponsorblock)
+      blocker = Blocker.new(chromecast, sponsorblock, @mute_ads)
 
       blocker.run
     end

--- a/src/castblock.cr
+++ b/src/castblock.cr
@@ -21,7 +21,7 @@ module Castblock
     @[Clip::Doc("The category to block. It can be repeated to block multiple categories.")]
     @categories = ["sponsor"]
     @[Clip::Option("--mute-ads")]
-    @[Clip::Doc("Enable auto muting adsense ads on youtube")]
+    @[Clip::Doc("Enable auto muting adsense ads on youtube.")]
     @mute_ads : Bool = false
 
     def run : Nil

--- a/src/chromecast.cr
+++ b/src/chromecast.cr
@@ -71,8 +71,12 @@ class Castblock::Chromecast
 
           begin
             message = WatchMessage.from_json(output)
-            if message.payload && (payload_data = WatchMessagePayload.from_json(message.payload.as(String)))
-              message.payload_data = payload_data
+            message.payload.as?(String).try do |payload|
+              begin
+                message.payload_data = WatchMessagePayload.from_json(payload)
+              rescue ex
+                Log.debug { "Unhandled payload: #{ex}" }
+              end
             end
           rescue ex
             Log.debug { "Invalid message: #{ex}" }

--- a/src/chromecast.cr
+++ b/src/chromecast.cr
@@ -71,6 +71,9 @@ class Castblock::Chromecast
 
           begin
             message = WatchMessage.from_json(output)
+            if message.payload && (payload_data = WatchMessagePayload.from_json(message.payload.as(String)))
+              message.payload_data = payload_data
+            end
           rescue ex
             Log.debug { "Invalid message: #{ex}" }
           else

--- a/src/chromecast.cr
+++ b/src/chromecast.cr
@@ -44,6 +44,18 @@ class Castblock::Chromecast
     end
   end
 
+  def set_mute(device : Device, value : Bool) : Nil
+    params = HTTP::Params.encode({
+      "uuid"    => device.uuid,
+    })
+    response = client.post("/#{value ? "" : "un"}mute?" + params)
+
+    if !response.status.success?
+      Log.error &.emit("Error with mute", status_code: response.status_code, error: response.body)
+      raise CommandError.new
+    end
+  end
+
   def start_watcher(device : Device, continue : Channel(Nil), &block : WatchMessage ->) : Nil
     loop do
       Log.info &.emit("Connect to device", uuid: device.uuid)

--- a/src/chromecast/watch_message.cr
+++ b/src/chromecast/watch_message.cr
@@ -4,8 +4,9 @@ class Castblock::Chromecast
   struct WatchMessage
     include JSON::Serializable
 
-    getter application : Application
+    getter application : Application?
     getter media : Media?
+    getter payload : String?
   end
 
   struct Application

--- a/src/chromecast/watch_message.cr
+++ b/src/chromecast/watch_message.cr
@@ -7,8 +7,7 @@ class Castblock::Chromecast
     getter application : Application?
     getter media : Media?
     getter payload : String?
-    getter payload_data : WatchMessagePayload?
-    setter payload_data : WatchMessagePayload?
+    property payload_data : WatchMessagePayload?
   end
 
   struct Application

--- a/src/chromecast/watch_message.cr
+++ b/src/chromecast/watch_message.cr
@@ -7,6 +7,8 @@ class Castblock::Chromecast
     getter application : Application?
     getter media : Media?
     getter payload : String?
+    getter payload_data : WatchMessagePayload?
+    setter payload_data : WatchMessagePayload?
   end
 
   struct Application
@@ -32,5 +34,32 @@ class Castblock::Chromecast
     @[JSON::Field(key: "currentTime")]
     getter current_time : Float64
     getter media : Media
+  end
+
+  struct WatchMessagePayload
+    include JSON::Serializable
+
+    struct PayloadStatus
+      include JSON::Serializable
+
+      struct PayloadVolume
+        include JSON::Serializable
+
+        getter muted : Bool
+      end
+
+      struct PayloadCustomData
+        include JSON::Serializable
+
+        @[JSON::Field(key: "playerState")]
+        getter player_state : Int32
+      end
+
+      getter volume : PayloadVolume
+      @[JSON::Field(key: "customData")]
+      getter custom_data : PayloadCustomData
+    end
+
+    getter status : Array(PayloadStatus)
   end
 end


### PR DESCRIPTION
This is a proof of concept for automatically muting / unmuting native youtube ads shown on chromecast. It uses the (seemingly) magic number 1081 which playerState is set to while ads are running, and I added a set_mute function which uses the http api of go-chromecast. I also added a --mute-ads flag to enable this behavior.

I'm not particularly attached to this implementation since I had to change some stuff in the WatchMessage struct due to not being familiar with crystal. Let me know what you think - it seems to work pretty well so far. Repeated calls to mute/unmute are not handled but it doesn't seem to harm anything. There are other improvements that could be made like cleaner parsing of the payload json.

Edit: Also there might still be a bug with the payload json traversal, I tried to prevent cases that would cause a fatal error but it happens occasionally