### PR TITLE
[Feature] Merge multiple segments / skip adjacent segments with threshold parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Available options:
 * `--category`: specify the [category of segments](https://github.com/ajayyy/SponsorBlock/wiki/Types#category) to skip.
   It can be repeated to specify many categories.
   Default to "sponsor".
+* `--merge-threshold`: The maximum number of seconds between segments to be merged.
+  Adjust this value to skip multiple adjacent segments that don't overlap.
 * `--mute-ads`: enable auto mute during native YouTube ads. These are different
   from in-video sponsors, and are typically blocked by browser extension ad blockers.
 

--- a/src/blocker.cr
+++ b/src/blocker.cr
@@ -84,14 +84,16 @@ class Castblock::Blocker
       segment_start = segment.segment[0]
       segment_end = Math.min(segment.segment[1], media.media.duration).to_f
 
-      if segment_start <= media.current_time < segment_end - Math.max(5, @seek_to_offset)
+      # Check if we are in the segment
+      if segment_start <= media.current_time < segment_end
         Log.info &.emit(
-          "Found a #{segment.category} segment, skipping it.",
+          "Found a #{segment.category} segment.",
           id: media.media.content_id,
           start: segment_start,
           end: segment_end,
         )
 
+        # Extend segment_end using merge_threshold
         sorted_segments = segments.sort { |x, y| x.segment[0] <=> y.segment[0] }
         sorted_segments.each do |segment_next|
           if segment_next.segment[0] - @merge_threshold <= segment_end < segment_next.segment[1]
@@ -100,20 +102,30 @@ class Castblock::Blocker
           end
         end
 
-        begin
-          @chromecast.seek_to(device, segment_end - @seek_to_offset)
-        rescue Chromecast::CommandError
-          Log.error &.emit("Trying to reconnect to the device", name: device.name, uuid: device.uuid)
-          @chromecast.disconnect(device)
+        # Check if the segment meets minimum length
+        if media.current_time < segment_end - Math.max(5, @seek_to_offset)
+          Log.info &.emit(
+            "Segment meets criteria, skipping it.",
+            id: media.media.content_id,
+            start: segment_start,
+            end: segment_end,
+          )
           begin
-            @chromecast.connect(device)
+            @chromecast.seek_to(device, segment_end - @seek_to_offset)
           rescue Chromecast::CommandError
-            Log.error &.emit("Error while reconnecting to the device", name: device.name, uuid: device.uuid)
-            remove_device(device, disconnect: false)
+            Log.error &.emit("Trying to reconnect to the device", name: device.name, uuid: device.uuid)
+            @chromecast.disconnect(device)
+            begin
+              @chromecast.connect(device)
+            rescue Chromecast::CommandError
+              Log.error &.emit("Error while reconnecting to the device", name: device.name, uuid: device.uuid)
+              remove_device(device, disconnect: false)
+            end
           end
+          # Only break if segment met the criteria and was skipped
+          break
         end
 
-        break
       end
     end
   end

--- a/src/castblock.cr
+++ b/src/castblock.cr
@@ -23,6 +23,11 @@ module Castblock
     @[Clip::Option("--mute-ads")]
     @[Clip::Doc("Enable auto muting adsense ads on youtube.")]
     @mute_ads : Bool = false
+    @[Clip::Option("--merge-threshold")]
+    @[Clip::Doc("The maximum number of seconds between segments to be merged. " \
+                "Adjust this value to skip multiple adjacent segments that don't overlap.")]
+    @merge_threshold = 0.0
+
 
     def read_env
       # If a config option equals its default value, we try to read it from the env.
@@ -42,6 +47,10 @@ module Castblock
       if @mute_ads == false && (mute_ads = ENV["MUTE_ADS"]?)
         @mute_ads = mute_ads.downcase == "true"
       end
+
+      if @merge_threshold == 0.0 && (merge_threshold = ENV["MERGE_THRESHOLD"]?)
+        @merge_threshold == merge_threshold.to_f
+      end
     end
 
     def run : Nil
@@ -58,7 +67,7 @@ module Castblock
       end
 
       chromecast = Chromecast.new
-      blocker = Blocker.new(chromecast, sponsorblock, @seek_to_offset, @mute_ads)
+      blocker = Blocker.new(chromecast, sponsorblock, @seek_to_offset, @mute_ads, @merge_threshold)
 
       blocker.run
     end


### PR DESCRIPTION
I got tired of waiting for 2 skips for ad reads before intro segments, so I made this and use 1.0 as a threshold and it seems to work great!

Note: This would change the default behavior to skipping multiple overlapping segments in 1 skip, I think that's a nice improvement if the code seems safe