### PR TITLE
Added docker compose example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ services:
       # - OFFSET=2 # Optional
       # - MERGE_THRESHOLD=2 # Optional
       # - MUTE_ADS=true # Optional
-      # Full list of categories https://wiki.sponsor.ajay.app/w/Types
+      # Full list of categories https://wiki.sponsor.ajay.app/w/Types#Category
 ```
 
 Most environment variables are optional as can be seen, more info on what they do can be found in the [available options section](#available-options).
 
 ### From source
 
-You need to install [go-chromecast](https://wiki.sponsor.ajay.app/w/Types) first, and to make it available in your PATH.
+You need to install [go-chromecast](https://wiki.sponsor.ajay.app/w/Types#Category) first, and to make it available in your PATH.
 Then you need a working Crystal environment and run `shards build --release`.
 The binary is in `./bin/castblock`.
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,28 @@ If not, please open an issue :)
 
 The amd64 and arm64 images are based on Alpine and weigh only 20Mo, but due to [a missing cross compilation target](https://github.com/crystal-lang/crystal/issues/5467) the arm images use Debian and weights 47Mo.
 
+### Docker Compose
+
+```
+version: '3.3'
+services:
+  castblock:
+    network_mode: host
+    image: erdnaxeli/castblock
+    environment:
+      - CATEGORIES=sponsor,selfpromo
+      # - DEBUG=false # Optional
+      # - OFFSET=2 # Optional
+      # - MERGE_THRESHOLD=2 # Optional
+      # - MUTE_ADS=true # Optional
+      # Full list of categories https://wiki.sponsor.ajay.app/w/Types
+```
+
+Most environment variables are optional as can be seen, more info on what they do can be found in the [available options section](#available-options).
+
 ### From source
 
-You need to install [go-chromecast](https://github.com/vishen/go-chromecast) first, and to make it available in your PATH.
+You need to install [go-chromecast](https://wiki.sponsor.ajay.app/w/Types) first, and to make it available in your PATH.
 Then you need a working Crystal environment and run `shards build --release`.
 The binary is in `./bin/castblock`.
 
@@ -41,7 +60,7 @@ Segments shorter that 5s cannot be skipped. The last 20 videos' segments are cac
 If you have any issue, please run CastBlock with the `--debug` flag, try to reproduce your problem and past the output in the issue.
 You can use the flag with docker too like this: `docker run --rm --network host erdnaxeli/castblock --debug`.
 
-Available options:
+##### Available options:
 
 * `--debug`: run the app with the debug logs.
 * `--offset`: set an offset to use before the end of the segment, in seconds.

--- a/contrib/docker-compose.yml
+++ b/contrib/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     image: erdnaxeli/castblock
     environment:
       - CATEGORIES=sponsor,selfpromo
-      # Full list of categories https://github.com/ajayyy/SponsorBlock/wiki/Types#category
+      # Full list of categories https://wiki.sponsor.ajay.app/w/Types

--- a/contrib/docker-compose.yml
+++ b/contrib/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     image: erdnaxeli/castblock
     environment:
       - CATEGORIES=sponsor,selfpromo
-      # Full list of categories https://wiki.sponsor.ajay.app/w/Types
+      # Full list of categories https://wiki.sponsor.ajay.app/w/Types#Category


### PR DESCRIPTION
Added the docker-compose file as example to the readme, as well as updating the references to the sponsorblock category urls.