### PR TITLE
fix: Add SKIP_ADS env var handling, fixes #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ services:
       - CATEGORIES=sponsor,selfpromo
       # - DEBUG=false # Optional
       # - OFFSET=2 # Optional
-      # - MERGE_THRESHOLD=2 # Optional
       # - MUTE_ADS=true # Optional
+      # - SKIP_ADS=true # Optional
+      # - MERGE_THRESHOLD=2 # Optional
 ```
 
 Most environment variables are optional as can be seen, more info on what they do can be found in the [available options section](#available-options).
@@ -84,6 +85,7 @@ All options can also be read from the environment variables:
 * `CATEGORIES=sponsor,interaction`
 * `MUTE_ADS=true`
 * `SKIP_ADS=true`
+* `MERGE_THRESHOLD=1`
 
 ## Contributing
 

--- a/src/castblock.cr
+++ b/src/castblock.cr
@@ -48,6 +48,7 @@ module Castblock
       @seek_to_offset = read_env_int(@seek_to_offset, 0, "OFFSET")
       @categories = read_env_str_array(@categories, ["sponsor"], "CATEGORIES")
       @mute_ads = read_env_bool(@mute_ads, false, "MUTE_ADS")
+      @skip_ads = read_env_bool(@skip_ads, false, "SKIP_ADS")
       @merge_threshold = read_env_float(@merge_threshold, 0.0, "MERGE_THRESHOLD")
     end
 


### PR DESCRIPTION
I discovered when moving to a new docker host and switching to env vars that --skip-ads was missing a matching env var.