### PR TITLE
chore: bump ameba version

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.3.1
+    version: 1.6.3
 
   clip:
     git: https://github.com/erdnaxeli/clip.git


### PR DESCRIPTION
It doesn't seem to build with older versions

Closes #60 